### PR TITLE
[PATCH] fixed type issue, updated SSH_MSG_DISCONNECT

### DIFF
--- a/src/packet.c
+++ b/src/packet.c
@@ -419,8 +419,8 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
                     size_t datalen, int macstate)
 {
     int rc = 0;
-    char *message = NULL;
-    char *language = NULL;
+    unsigned char *message = NULL;
+    unsigned char *language = NULL;
     size_t message_len = 0;
     size_t language_len = 0;
     LIBSSH2_CHANNEL *channelp = NULL;
@@ -472,33 +472,23 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
 
         case SSH_MSG_DISCONNECT:
             if(datalen >= 5) {
-                size_t reason = _libssh2_ntohu32(data + 1);
+                uint32_t reason = 0;
+                struct string_buf buf;
+                buf.data = (unsigned char *)data;
+                buf.dataptr = buf.data;
+                buf.len = datalen;
+                buf.dataptr++; /* advance past type */
 
-                if(datalen >= 9) {
-                    message_len = _libssh2_ntohu32(data + 5);
+                _libssh2_get_u32(&buf, &reason);
+                _libssh2_get_string(&buf, &message, &message_len);
+                _libssh2_get_string(&buf, &language, &language_len);
 
-                    if(message_len < datalen-13) {
-                        /* 9 = packet_type(1) + reason(4) + message_len(4) */
-                        message = (char *) data + 9;
-
-                        language_len =
-                            _libssh2_ntohu32(data + 9 + message_len);
-                        language = (char *) data + 9 + message_len + 4;
-
-                        if(language_len > (datalen-13-message_len)) {
-                            /* bad input, clear info */
-                            language = message = NULL;
-                            language_len = message_len = 0;
-                        }
-                    }
-                    else
-                        /* bad size, clear it */
-                        message_len = 0;
-                }
                 if(session->ssh_msg_disconnect) {
-                    LIBSSH2_DISCONNECT(session, reason, message,
-                                       message_len, language, language_len);
+                    LIBSSH2_DISCONNECT(session, reason, (const char *)message,
+                                       message_len, (const char *)language,
+                                       language_len);
                 }
+
                 _libssh2_debug(session, LIBSSH2_TRACE_TRANS,
                                "Disconnect(%d): %s(%s)", reason,
                                message, language);


### PR DESCRIPTION
SSH_MSG_DISCONNECT now also uses  _libssh2_get API.

Backport patch from:
https://github.com/libssh2/libssh2/commit/1c6fa92b77e34d089493fe6d3e2c6c8775858b94.patch

Fixes CVE: https://nvd.nist.gov/vuln/detail/CVE-2019-17498

Signed-off-by: Phoong, Stanley Cheong Kwan <stanley.cheong.kwan.phoong@intel.com>